### PR TITLE
[Feat] #6 - 영화차트 리스트 조회 API 구현

### DIFF
--- a/cgv/src/main/java/org/sopt/server/cgv/controller/MovieController.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/controller/MovieController.java
@@ -1,4 +1,26 @@
 package org.sopt.server.cgv.controller;
 
+import lombok.RequiredArgsConstructor;
+import org.sopt.server.cgv.dto.response.MovieListResponseDto;
+import org.sopt.server.cgv.global.response.ApiResponse;
+import org.sopt.server.cgv.global.response.SuccessType;
+import org.sopt.server.cgv.service.MovieService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/movie")
+@RequiredArgsConstructor
 public class MovieController {
+
+    private final MovieService movieService;
+
+    @GetMapping
+    public ApiResponse<List<MovieListResponseDto>> getMovieList() {
+        return ApiResponse.success(SuccessType.GET_MOVIE_LIST_SUCCESS, movieService.getMovieList());
+    }
+
 }

--- a/cgv/src/main/java/org/sopt/server/cgv/dto/movieListResponseDto.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/dto/movieListResponseDto.java
@@ -1,4 +1,0 @@
-package org.sopt.server.cgv.dto;
-
-public class movieListResponseDto {
-}

--- a/cgv/src/main/java/org/sopt/server/cgv/dto/response/MovieListResponseDto.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/dto/response/MovieListResponseDto.java
@@ -1,0 +1,26 @@
+package org.sopt.server.cgv.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import org.sopt.server.cgv.domain.Movie;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record MovieListResponseDto(
+        Long movieId,
+        String title,
+        String posterUrl,
+        String ranking,
+        String totalAudience,
+        int likeCount
+) {
+    public static MovieListResponseDto of(Movie movie) {
+        return new MovieListResponseDto(
+                movie.getId(),
+                movie.getTitle(),
+                movie.getPosterURL(),
+                movie.getRanking(),
+                movie.getTotalAudience(),
+                movie.getLike()
+        );
+    }
+}

--- a/cgv/src/main/java/org/sopt/server/cgv/global/response/ApiResponse.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/global/response/ApiResponse.java
@@ -8,14 +8,13 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@JsonPropertyOrder({"code", "status", "success", "data"})
+@JsonPropertyOrder({"code", "status", "data"})
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ApiResponse<T> {
 
     private final int code;
     private final String status;
-    private final boolean success;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private T data;
@@ -25,7 +24,7 @@ public class ApiResponse<T> {
     }
 
     public static <T> ApiResponse<T> success(SuccessType successType, T data) {
-        return new ApiResponse<T>(successType.getHttpStatusCode(), successType.getMessage(), true, data);
+        return new ApiResponse<T>(successType.getHttpStatusCode(), successType.getMessage(), data);
     }
 
     public static ApiResponse<?> error(ErrorType errorType) {
@@ -37,14 +36,14 @@ public class ApiResponse<T> {
     }
 
     public static <T> ApiResponse<T> error(ErrorType errorType, String message, T data) {
-        return new ApiResponse<>(errorType.getHttpStatusCode(), message, false, data);
+        return new ApiResponse<>(errorType.getHttpStatusCode(), message, data);
     }
 
     public static <T> ApiResponse<Exception> error(ErrorType errorType, Exception e) {
-        return new ApiResponse<>(errorType.getHttpStatusCode(), errorType.getMessage(), false, e);
+        return new ApiResponse<>(errorType.getHttpStatusCode(), errorType.getMessage(), e);
     }
 
     public static <T> ApiResponse<T> error(ErrorType errorType, T data) {
-        return new ApiResponse<>(errorType.getHttpStatusCode(), errorType.getMessage(), false, data);
+        return new ApiResponse<>(errorType.getHttpStatusCode(), errorType.getMessage(), data);
     }
 }

--- a/cgv/src/main/java/org/sopt/server/cgv/global/response/SuccessType.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/global/response/SuccessType.java
@@ -13,7 +13,7 @@ public enum SuccessType {
     /**
      * 200 OK
      */
-    GET_USER_SUCCESS(HttpStatus.OK, "특정 사용자 조회 성공");
+    GET_MOVIE_LIST_SUCCESS(HttpStatus.OK, "무비차트 리스트 조회에 성공했습니다.");
 
     /**
      * 201 CREATED

--- a/cgv/src/main/java/org/sopt/server/cgv/repository/MovieRepository.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/repository/MovieRepository.java
@@ -1,4 +1,8 @@
 package org.sopt.server.cgv.repository;
 
-public class MovieRepository {
+import org.sopt.server.cgv.domain.Movie;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MovieRepository extends JpaRepository<Movie, Long> {
+
 }

--- a/cgv/src/main/java/org/sopt/server/cgv/service/MovieService.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/service/MovieService.java
@@ -1,4 +1,26 @@
 package org.sopt.server.cgv.service;
 
+import lombok.RequiredArgsConstructor;
+import org.sopt.server.cgv.dto.response.MovieListResponseDto;
+import org.sopt.server.cgv.global.response.ApiResponse;
+import org.sopt.server.cgv.repository.MovieRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MovieService {
+
+    private final MovieRepository movieRepository;
+
+    public List<MovieListResponseDto> getMovieList() {
+        return movieRepository.findAll().stream()
+                .map(MovieListResponseDto::of)
+                .collect(Collectors.toList());
+    }
+
 }


### PR DESCRIPTION
## 🔥*Pull Request*

### 📟 관련 이슈
- Resolved: #6

### 💻 작업 내용
-  영화 차트 리스트 조회 API 구현
<img width="1066" alt="스크린샷 2023-11-21 오후 2 39 42" src="https://github.com/DOSOPT-CDS-WEB-4/CGV-SERVER/assets/75068759/5456ee5f-2e94-438d-a82e-a1d4e281e76b">

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
- API 명세서 양식에 맞게 ApiResponse의 Success 값을 없앴습니다. 
- dto패키지 내에 response와 request를 구분하기 위해 추가적인 패키징 작업을 진행했습니다. request패키지는 결제하기 API 구현할때 추가해놓겠습니다.
- 현재는 finaAll()로 해주고 있는데 주간 순위이니까 OrderBy를 해주는게 좋을지 고민이 됩니다.. 어떻게 생각하시나요?
