### PR TITLE
[Feat] #6 - 빠른 예매 API 구현

### DIFF
--- a/cgv/src/main/java/org/sopt/server/cgv/controller/ReservationController.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/controller/ReservationController.java
@@ -1,0 +1,39 @@
+package org.sopt.server.cgv.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.server.cgv.domain.Movie;
+import org.sopt.server.cgv.domain.Region;
+import org.sopt.server.cgv.dto.response.MovieScreenScheduleResponseDto;
+import org.sopt.server.cgv.dto.response.QuickReservationResponseDto;
+import org.sopt.server.cgv.global.response.ApiResponse;
+import org.sopt.server.cgv.global.response.SuccessType;
+import org.sopt.server.cgv.service.MovieService;
+import org.sopt.server.cgv.service.RegionService;
+import org.sopt.server.cgv.service.ScheduleService;
+import org.sopt.server.cgv.service.ScreenService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/reservation")
+public class ReservationController {
+
+    private final MovieService movieService;
+    private final RegionService regionService;
+    private final ScreenService screenService;
+    private final ScheduleService scheduleService;
+
+    @GetMapping("/{movieId}")
+    public ApiResponse<QuickReservationResponseDto> registerReservation(@PathVariable Long movieId,
+                                                                        @RequestParam(value = "region") String regionName,
+                                                                        @RequestParam(value = "type", required = false) String screenType) {
+        Movie movie = movieService.getMovieInfo(movieId);
+        Region region = regionService.getRegionInfo(regionName);
+        List<Long> screenIdList = screenService.getScreenIdList(movieId, region.getId(), screenType);
+        List<MovieScreenScheduleResponseDto> movieScreenSchedules = scheduleService.getMovieScreenScheduleInfo(screenIdList, movie.getRunningTime());
+        return ApiResponse.success(SuccessType.GET_MOVIE_LIST_SUCCESS, QuickReservationResponseDto.of(
+                movie, region, movieScreenSchedules));
+    }
+}

--- a/cgv/src/main/java/org/sopt/server/cgv/controller/ReservationController.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/controller/ReservationController.java
@@ -33,7 +33,7 @@ public class ReservationController {
         Region region = regionService.getRegionInfo(regionName);
         List<Long> screenIdList = screenService.getScreenIdList(movieId, region.getId(), screenType);
         List<MovieScreenScheduleResponseDto> movieScreenSchedules = scheduleService.getMovieScreenScheduleInfo(screenIdList, movie.getRunningTime());
-        return ApiResponse.success(SuccessType.GET_MOVIE_LIST_SUCCESS, QuickReservationResponseDto.of(
+        return ApiResponse.success(SuccessType.GET_MOVIE_AND_SCREEN_TYPE_AND_SCHEDULE_LIST_SUCCESS, QuickReservationResponseDto.of(
                 movie, region, movieScreenSchedules));
     }
 }

--- a/cgv/src/main/java/org/sopt/server/cgv/domain/RegionName.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/domain/RegionName.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum RegionName {
 
-    HONDGAE("홍대"),
+    HONGDAE("홍대"),
     CHEONGDAM("청담씨네시티"),
     MOKDONG("목동"),
     PIKADILI("피카디리1958"),

--- a/cgv/src/main/java/org/sopt/server/cgv/domain/Schedule.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/domain/Schedule.java
@@ -34,7 +34,7 @@ public class Schedule {
     private Screen screen;
 
     public void updateSeats(int seats) {
-        if(this.emptySeats < 2) {
+        if (this.emptySeats < 2) {
             throw new CommonException(ErrorType.NO_SEAT_SCHEDULE_ERROR);
         } else {
             this.emptySeats -= seats;

--- a/cgv/src/main/java/org/sopt/server/cgv/domain/Schedule.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/domain/Schedule.java
@@ -34,7 +34,7 @@ public class Schedule {
     private Screen screen;
 
     public void updateSeats(int seats) {
-        if (this.emptySeats < 2) {
+        if (this.emptySeats < seats) {
             throw new CommonException(ErrorType.NO_SEAT_SCHEDULE_ERROR);
         } else {
             this.emptySeats -= seats;

--- a/cgv/src/main/java/org/sopt/server/cgv/domain/Screen.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/domain/Screen.java
@@ -23,7 +23,7 @@ public class Screen {
     private ScreenType screenType;
 
     @Column(nullable = false)
-    private String Place;
+    private String place;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "movie_id")

--- a/cgv/src/main/java/org/sopt/server/cgv/dto/response/MovieScreenScheduleResponseDto.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/dto/response/MovieScreenScheduleResponseDto.java
@@ -1,0 +1,28 @@
+package org.sopt.server.cgv.dto.response;
+
+import org.sopt.server.cgv.domain.Schedule;
+import org.sopt.server.cgv.domain.ScreenType;
+
+import java.time.LocalDateTime;
+
+public record MovieScreenScheduleResponseDto(
+        ScreenType screenType,
+        String place,
+        LocalDateTime startTime,
+        LocalDateTime endTime,
+        int totalSeats,
+        int emptySeats,
+        boolean reservationAvailability
+) {
+    public static MovieScreenScheduleResponseDto of(Schedule schedule, LocalDateTime endTime, boolean reservationAvailability) {
+        return new MovieScreenScheduleResponseDto(
+                schedule.getScreen().getScreenType(),
+                schedule.getScreen().getPlace(),
+                schedule.getStartTime(),
+                endTime,
+                schedule.getTotalSeats(),
+                schedule.getEmptySeats(),
+                reservationAvailability
+        );
+    }
+}

--- a/cgv/src/main/java/org/sopt/server/cgv/dto/response/QuickReservationResponseDto.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/dto/response/QuickReservationResponseDto.java
@@ -1,0 +1,42 @@
+package org.sopt.server.cgv.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import org.sopt.server.cgv.domain.*;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record QuickReservationResponseDto(
+        String title,
+        String summary,
+        LocalDate openingDate,
+        Genre genre,
+        int runningTime,
+        Country country,
+        String poster,
+        String background,
+        List<RegionName> regionNames,
+        RegionName currentRegion,
+        List<ScreenType> screenTypes,
+        List<MovieScreenScheduleResponseDto> movieScreenSchedules
+) {
+    public static QuickReservationResponseDto of(Movie movie, Region region, List<MovieScreenScheduleResponseDto> movieScreenSchedules) {
+        return new QuickReservationResponseDto(
+                movie.getTitle(),
+                movie.getSummary(),
+                movie.getOpeningDate(),
+                movie.getGenre(),
+                movie.getRunningTime(),
+                movie.getCountry(),
+                movie.getPosterURL(),
+                movie.getBackgroundURL(),
+                Arrays.stream(RegionName.values()).toList(),
+                region.getRegionName(),
+                Arrays.stream(ScreenType.values()).toList(),
+                movieScreenSchedules
+        );
+    }
+}

--- a/cgv/src/main/java/org/sopt/server/cgv/global/response/ErrorType.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/global/response/ErrorType.java
@@ -22,6 +22,9 @@ public enum ErrorType {
     /**
      * 404 NOT FOUND
      */
+    NOT_FOUND_MOVIE_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 영화입니다"),
+    NOT_FOUND_REGION_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 지역입니다"),
+    NOT_FOUND_SCREEN_TYPE_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 상영관입니다"),
     NOT_FOUND_SCHEDULE_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 상영 스케줄입니다"),
 
     /**

--- a/cgv/src/main/java/org/sopt/server/cgv/global/response/SuccessType.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/global/response/SuccessType.java
@@ -14,6 +14,7 @@ public enum SuccessType {
      * 200 OK
      */
     GET_MOVIE_LIST_SUCCESS(HttpStatus.OK, "무비차트 리스트 조회에 성공했습니다."),
+    GET_MOVIE_AND_SCREEN_TYPE_AND_SCHEDULE_LIST_SUCCESS(HttpStatus.OK, "영화 정보 및 상영관, 상영시간 조회에 성공했습니다."),
     PATCH_RESERVE_SUCCESS(HttpStatus.OK, "영화 에매 결제에 성공했습니다.");
 
 

--- a/cgv/src/main/java/org/sopt/server/cgv/repository/MovieRepository.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/repository/MovieRepository.java
@@ -1,12 +1,14 @@
 package org.sopt.server.cgv.repository;
 
 import org.sopt.server.cgv.domain.Movie;
+import org.sopt.server.cgv.global.exception.CommonException;
+import org.sopt.server.cgv.global.response.ErrorType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MovieRepository extends JpaRepository<Movie, Long> {
 
     default Movie findByIdOrThrow(Long id) {
         return findById(id).orElseThrow(
-                () -> new IllegalStateException());
+                () -> new CommonException(ErrorType.NOT_FOUND_MOVIE_ERROR));
     }
 }

--- a/cgv/src/main/java/org/sopt/server/cgv/repository/MovieRepository.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/repository/MovieRepository.java
@@ -5,4 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MovieRepository extends JpaRepository<Movie, Long> {
 
+    default Movie findByIdOrThrow(Long id) {
+        return findById(id).orElseThrow(
+                () -> new IllegalStateException());
+    }
 }

--- a/cgv/src/main/java/org/sopt/server/cgv/repository/RegionRepository.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/repository/RegionRepository.java
@@ -2,6 +2,8 @@ package org.sopt.server.cgv.repository;
 
 import org.sopt.server.cgv.domain.Region;
 import org.sopt.server.cgv.domain.RegionName;
+import org.sopt.server.cgv.global.exception.CommonException;
+import org.sopt.server.cgv.global.response.ErrorType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -12,6 +14,6 @@ public interface RegionRepository extends JpaRepository<Region, Long> {
 
     default Region findByRegionNameOrThrow(RegionName regionName) {
         return findByRegionName(regionName).orElseThrow(
-                () -> new IllegalStateException());
+                () -> new CommonException(ErrorType.NOT_FOUND_REGION_ERROR));
     }
 }

--- a/cgv/src/main/java/org/sopt/server/cgv/repository/RegionRepository.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/repository/RegionRepository.java
@@ -1,4 +1,17 @@
 package org.sopt.server.cgv.repository;
 
-public class RegionRepository {
+import org.sopt.server.cgv.domain.Region;
+import org.sopt.server.cgv.domain.RegionName;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RegionRepository extends JpaRepository<Region, Long> {
+
+    Optional<Region> findByRegionName(RegionName regionName);
+
+    default Region findByRegionNameOrThrow(RegionName regionName) {
+        return findByRegionName(regionName).orElseThrow(
+                () -> new IllegalStateException());
+    }
 }

--- a/cgv/src/main/java/org/sopt/server/cgv/repository/ScheduleRepository.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/repository/ScheduleRepository.java
@@ -5,11 +5,14 @@ import org.sopt.server.cgv.global.exception.CommonException;
 import org.sopt.server.cgv.global.response.ErrorType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     default Schedule findByIdOrThrow(Long id) {
         return findById(id).orElseThrow(
                 () -> new CommonException(ErrorType.NOT_FOUND_SCHEDULE_ERROR));
     }
-    
+
+    List<Schedule> findByScreenIdIn(List<Long> screenIdList);
 }

--- a/cgv/src/main/java/org/sopt/server/cgv/repository/ScreenRepository.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/repository/ScreenRepository.java
@@ -1,4 +1,14 @@
 package org.sopt.server.cgv.repository;
 
-public class ScreenRepository {
+import org.sopt.server.cgv.domain.Screen;
+import org.sopt.server.cgv.domain.ScreenType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ScreenRepository extends JpaRepository<Screen, Long> {
+
+    List<Screen> findByMovieIdAndRegionIdAndScreenType(Long movieId, Long regionId, ScreenType screenType);
+
+    List<Screen> findByMovieIdAndRegionId(Long movieId, Long regionId);
 }

--- a/cgv/src/main/java/org/sopt/server/cgv/service/MovieService.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/service/MovieService.java
@@ -1,6 +1,7 @@
 package org.sopt.server.cgv.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.server.cgv.domain.Movie;
 import org.sopt.server.cgv.dto.response.MovieListResponseDto;
 import org.sopt.server.cgv.global.response.ApiResponse;
 import org.sopt.server.cgv.repository.MovieRepository;
@@ -21,6 +22,10 @@ public class MovieService {
         return movieRepository.findAll().stream()
                 .map(MovieListResponseDto::of)
                 .collect(Collectors.toList());
+    }
+
+    public Movie getMovieInfo(Long movieId) {
+        return movieRepository.findByIdOrThrow(movieId);
     }
 
 }

--- a/cgv/src/main/java/org/sopt/server/cgv/service/MovieService.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/service/MovieService.java
@@ -21,7 +21,7 @@ public class MovieService {
     public List<MovieListResponseDto> getMovieList() {
         return movieRepository.findAll().stream()
                 .map(MovieListResponseDto::of)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public Movie getMovieInfo(Long movieId) {

--- a/cgv/src/main/java/org/sopt/server/cgv/service/RegionService.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/service/RegionService.java
@@ -3,6 +3,8 @@ package org.sopt.server.cgv.service;
 import lombok.RequiredArgsConstructor;
 import org.sopt.server.cgv.domain.Region;
 import org.sopt.server.cgv.domain.RegionName;
+import org.sopt.server.cgv.global.exception.CommonException;
+import org.sopt.server.cgv.global.response.ErrorType;
 import org.sopt.server.cgv.repository.RegionRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +17,10 @@ public class RegionService {
     private final RegionRepository regionRepository;
 
     public Region getRegionInfo(String region) {
-        return regionRepository.findByRegionNameOrThrow(RegionName.valueOf(region));
+        try {
+            return regionRepository.findByRegionNameOrThrow(RegionName.valueOf(region));
+        } catch (IllegalArgumentException e) {
+            throw new CommonException(ErrorType.NOT_FOUND_REGION_ERROR);
+        }
     }
 }

--- a/cgv/src/main/java/org/sopt/server/cgv/service/RegionService.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/service/RegionService.java
@@ -1,4 +1,20 @@
 package org.sopt.server.cgv.service;
 
+import lombok.RequiredArgsConstructor;
+import org.sopt.server.cgv.domain.Region;
+import org.sopt.server.cgv.domain.RegionName;
+import org.sopt.server.cgv.repository.RegionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RegionService {
+
+    private final RegionRepository regionRepository;
+
+    public Region getRegionInfo(String region) {
+        return regionRepository.findByRegionNameOrThrow(RegionName.valueOf(region));
+    }
 }

--- a/cgv/src/main/java/org/sopt/server/cgv/service/ScheduleService.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/service/ScheduleService.java
@@ -3,15 +3,22 @@ package org.sopt.server.cgv.service;
 import lombok.RequiredArgsConstructor;
 import org.sopt.server.cgv.domain.Schedule;
 import org.sopt.server.cgv.dto.request.ReserveRequestDto;
+import org.sopt.server.cgv.dto.response.MovieScreenScheduleResponseDto;
 import org.sopt.server.cgv.dto.response.ReserveResponseDto;
 import org.sopt.server.cgv.repository.ScheduleRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ScheduleService {
+
+    private static final int HOUR = 60;
 
     private final ScheduleRepository scheduleRepository;
 
@@ -20,6 +27,16 @@ public class ScheduleService {
         Schedule schedule = scheduleRepository.findByIdOrThrow(requestDto.id());
         schedule.updateSeats(2);
         return ReserveResponseDto.of(schedule);
+    }
+
+    public List<MovieScreenScheduleResponseDto> getMovieScreenScheduleInfo(List<Long> screenIdList, int runningTime) {
+        List<Schedule> schedules = scheduleRepository.findByScreenIdIn(screenIdList);
+        return schedules.stream()
+                .map(schedule -> MovieScreenScheduleResponseDto.of(
+                        schedule,
+                        schedule.getStartTime().plusHours(runningTime / HOUR).plusMinutes(runningTime % HOUR),
+                        schedule.getStartTime().isBefore(LocalDateTime.now())
+                )).toList();
     }
 
 }

--- a/cgv/src/main/java/org/sopt/server/cgv/service/ScreenService.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/service/ScreenService.java
@@ -3,6 +3,8 @@ package org.sopt.server.cgv.service;
 import lombok.RequiredArgsConstructor;
 import org.sopt.server.cgv.domain.Screen;
 import org.sopt.server.cgv.domain.ScreenType;
+import org.sopt.server.cgv.global.exception.CommonException;
+import org.sopt.server.cgv.global.response.ErrorType;
 import org.sopt.server.cgv.repository.ScreenRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,8 +22,11 @@ public class ScreenService {
         if (screenType == null) {
             return filterWhenScreenTypeNotExist(movieId, regionId);
         }
-
-        return filterWhenScreenTypeExist(movieId, regionId, screenType);
+        try {
+            return filterWhenScreenTypeExist(movieId, regionId, screenType);
+        } catch (IllegalArgumentException e) {
+            throw new CommonException(ErrorType.NOT_FOUND_SCREEN_TYPE_ERROR);
+        }
     }
 
     private List<Long> filterWhenScreenTypeExist(Long movieId, Long regionId, String screenType) {

--- a/cgv/src/main/java/org/sopt/server/cgv/service/ScreenService.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/service/ScreenService.java
@@ -1,4 +1,40 @@
 package org.sopt.server.cgv.service;
 
+import lombok.RequiredArgsConstructor;
+import org.sopt.server.cgv.domain.Screen;
+import org.sopt.server.cgv.domain.ScreenType;
+import org.sopt.server.cgv.repository.ScreenRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ScreenService {
+
+    private final ScreenRepository screenRepository;
+
+    public List<Long> getScreenIdList(Long movieId, Long regionId, String screenType) {
+        if (screenType == null) {
+            return filterWhenScreenTypeNotExist(movieId, regionId);
+        }
+
+        return filterWhenScreenTypeExist(movieId, regionId, screenType);
+    }
+
+    private List<Long> filterWhenScreenTypeExist(Long movieId, Long regionId, String screenType) {
+        return screenRepository.findByMovieIdAndRegionIdAndScreenType(movieId, regionId, ScreenType.valueOf(screenType))
+                .stream()
+                .map(Screen::getId)
+                .toList();
+    }
+
+    private List<Long> filterWhenScreenTypeNotExist(Long movieId, Long regionId) {
+        return screenRepository.findByMovieIdAndRegionId(movieId, regionId)
+                .stream()
+                .map(Screen::getId)
+                .toList();
+    }
 }


### PR DESCRIPTION
## 🔥*Pull Request*

### 📟 관련 이슈
- Resolved: #5 

### 💻 작업 내용
- 영화 정보 및 상영관, 상영 시간 조회 API 구현

1. 영화 정보와 지역 정보만 주어질 때
![image](https://github.com/DOSOPT-CDS-WEB-4/CGV-SERVER/assets/81404890/c4bb8b07-7b4d-43b9-ae2a-2b3cda1eb1d8)
 
2. 영화 정보와 지역 정보, 상영관까지 주어질 때
![image](https://github.com/DOSOPT-CDS-WEB-4/CGV-SERVER/assets/81404890/9a42d74a-a070-4511-bdca-479a317d8c14)

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
1. 개발을 다 마치고 문득 영화 정보 및 전체 상영관 조회 API와 지역, 날짜, 상영관 필터링 API를 한꺼번에 개발했다는 것을 깨달아 이걸 다시 분리해야하나 궁금합니다. -> 분리해야할 거 같긴한데
2. 1번 리뷰를 적다가 문득 날짜 필터링을 하지 않았다는 것을 깨달았습니다. 이슈 파고 다시 실행해보겠습니다.
3. 전반적인 코드리뷰를 원합니다.