### PR TITLE
[Recator] #13 - 영화 정보 조회 API 분리

### DIFF
--- a/cgv/src/main/java/org/sopt/server/cgv/controller/ReservationController.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/controller/ReservationController.java
@@ -3,6 +3,7 @@ package org.sopt.server.cgv.controller;
 import lombok.RequiredArgsConstructor;
 import org.sopt.server.cgv.domain.Movie;
 import org.sopt.server.cgv.domain.Region;
+import org.sopt.server.cgv.dto.response.MovieInfoResponseDto;
 import org.sopt.server.cgv.dto.response.MovieScreenScheduleResponseDto;
 import org.sopt.server.cgv.dto.response.QuickReservationResponseDto;
 import org.sopt.server.cgv.global.response.ApiResponse;
@@ -30,10 +31,11 @@ public class ReservationController {
                                                                         @RequestParam(value = "region") String regionName,
                                                                         @RequestParam(value = "type", required = false) String screenType) {
         Movie movie = movieService.getMovieInfo(movieId);
+        MovieInfoResponseDto movieInfo = MovieInfoResponseDto.of(movie);
         Region region = regionService.getRegionInfo(regionName);
         List<Long> screenIdList = screenService.getScreenIdList(movieId, region.getId(), screenType);
         List<MovieScreenScheduleResponseDto> movieScreenSchedules = scheduleService.getMovieScreenScheduleInfo(screenIdList, movie.getRunningTime());
         return ApiResponse.success(SuccessType.GET_MOVIE_AND_SCREEN_TYPE_AND_SCHEDULE_LIST_SUCCESS, QuickReservationResponseDto.of(
-                movie, region, movieScreenSchedules));
+                movieInfo, region, movieScreenSchedules));
     }
 }

--- a/cgv/src/main/java/org/sopt/server/cgv/dto/response/MovieInfoResponseDto.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/dto/response/MovieInfoResponseDto.java
@@ -1,0 +1,29 @@
+package org.sopt.server.cgv.dto.response;
+
+import org.sopt.server.cgv.domain.*;
+
+import java.time.LocalDate;
+
+public record MovieInfoResponseDto(
+        String title,
+        String summary,
+        LocalDate openingDate,
+        Genre genre,
+        int runningTime,
+        Country country,
+        String poster,
+        String background
+) {
+    public static MovieInfoResponseDto of(Movie movie) {
+        return new MovieInfoResponseDto(
+                movie.getTitle(),
+                movie.getSummary(),
+                movie.getOpeningDate(),
+                movie.getGenre(),
+                movie.getRunningTime(),
+                movie.getCountry(),
+                movie.getPosterURL(),
+                movie.getBackgroundURL()
+        );
+    }
+}

--- a/cgv/src/main/java/org/sopt/server/cgv/dto/response/QuickReservationResponseDto.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/dto/response/QuickReservationResponseDto.java
@@ -4,35 +4,20 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import org.sopt.server.cgv.domain.*;
 
-import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record QuickReservationResponseDto(
-        String title,
-        String summary,
-        LocalDate openingDate,
-        Genre genre,
-        int runningTime,
-        Country country,
-        String poster,
-        String background,
+        MovieInfoResponseDto movieInfo,
         List<RegionName> regionNames,
         RegionName currentRegion,
         List<ScreenType> screenTypes,
         List<MovieScreenScheduleResponseDto> movieScreenSchedules
 ) {
-    public static QuickReservationResponseDto of(Movie movie, Region region, List<MovieScreenScheduleResponseDto> movieScreenSchedules) {
+    public static QuickReservationResponseDto of(MovieInfoResponseDto movieInfo, Region region, List<MovieScreenScheduleResponseDto> movieScreenSchedules) {
         return new QuickReservationResponseDto(
-                movie.getTitle(),
-                movie.getSummary(),
-                movie.getOpeningDate(),
-                movie.getGenre(),
-                movie.getRunningTime(),
-                movie.getCountry(),
-                movie.getPosterURL(),
-                movie.getBackgroundURL(),
+                movieInfo,
                 Arrays.stream(RegionName.values()).toList(),
                 region.getRegionName(),
                 Arrays.stream(ScreenType.values()).toList(),


### PR DESCRIPTION
## 🔥*Pull Request*

### 📟 관련 이슈
- Resolved: #13 

### 💻 작업 내용
- QuickReservationResponseDto에서 영화 정보를 제공해주는 MovieInfoResponseDto를 분리해주었습니다.
- api도 분리해주려고 했으나 이후 지역, 상영관, 상영시간 정보를 가져오는 과정에서 불가피하게 movieId를 통해 영화 정보를 다시 찾아야 하기 때문에 굳이 분리하지 않아도 되겠다는 생각이 들었습니다.

### 📝 리뷰 노트
- 만약 좋은 방법이 떠오른다면 언제든지 말씀해주세요!
