### PR TITLE
[Feat] #15 - 기존 빠른예매 API에 날짜 필터링 추가

### DIFF
--- a/cgv/.gitignore
+++ b/cgv/.gitignore
@@ -38,4 +38,4 @@ out/
 
 .DS_STORE
 
-/src/main/resources
+application-secret.properties

--- a/cgv/src/main/java/org/sopt/server/cgv/controller/ReservationController.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/controller/ReservationController.java
@@ -14,6 +14,7 @@ import org.sopt.server.cgv.service.ScheduleService;
 import org.sopt.server.cgv.service.ScreenService;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -29,12 +30,13 @@ public class ReservationController {
     @GetMapping("/{movieId}")
     public ApiResponse<QuickReservationResponseDto> registerReservation(@PathVariable Long movieId,
                                                                         @RequestParam(value = "region") String regionName,
+                                                                        @RequestParam(value = "date") LocalDate date,
                                                                         @RequestParam(value = "type", required = false) String screenType) {
         Movie movie = movieService.getMovieInfo(movieId);
         MovieInfoResponseDto movieInfo = MovieInfoResponseDto.of(movie);
         Region region = regionService.getRegionInfo(regionName);
         List<Long> screenIdList = screenService.getScreenIdList(movieId, region.getId(), screenType);
-        List<MovieScreenScheduleResponseDto> movieScreenSchedules = scheduleService.getMovieScreenScheduleInfo(screenIdList, movie.getRunningTime());
+        List<MovieScreenScheduleResponseDto> movieScreenSchedules = scheduleService.getMovieScreenScheduleInfo(screenIdList, movie.getRunningTime(), date);
         return ApiResponse.success(SuccessType.GET_MOVIE_AND_SCREEN_TYPE_AND_SCHEDULE_LIST_SUCCESS, QuickReservationResponseDto.of(
                 movieInfo, region, movieScreenSchedules));
     }

--- a/cgv/src/main/java/org/sopt/server/cgv/service/ScheduleService.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/service/ScheduleService.java
@@ -9,6 +9,7 @@ import org.sopt.server.cgv.repository.ScheduleRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,14 +30,14 @@ public class ScheduleService {
         return ReserveResponseDto.of(schedule);
     }
 
-    public List<MovieScreenScheduleResponseDto> getMovieScreenScheduleInfo(List<Long> screenIdList, int runningTime) {
-        List<Schedule> schedules = scheduleRepository.findByScreenIdIn(screenIdList);
-        return schedules.stream()
+    public List<MovieScreenScheduleResponseDto> getMovieScreenScheduleInfo(List<Long> screenIdList, int runningTime, LocalDate date) {
+        return scheduleRepository.findByScreenIdIn(screenIdList)
+                .stream()
+                .filter(schedule -> schedule.getStartTime().toLocalDate().equals(date))
                 .map(schedule -> MovieScreenScheduleResponseDto.of(
                         schedule,
                         schedule.getStartTime().plusHours(runningTime / HOUR).plusMinutes(runningTime % HOUR),
                         schedule.getStartTime().isBefore(LocalDateTime.now())
                 )).toList();
     }
-
 }

--- a/cgv/src/main/resources/application.yml
+++ b/cgv/src/main/resources/application.yml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${DATABASE_ENDPOINT_URL}:3306/${DATABASE_NAME}?useSSL=true&useUnicode=true&serverTimezone=Asia/Seoul
+    username: ${DATABASE_USER}
+    password: ${DATABASE_PASSWORD}
+
+  config:
+    import: application-secret.properties
+
+  jpa:
+    show_sql: true
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+


### PR DESCRIPTION
## 🔥*Pull Request*

### 📟 관련 이슈
- Resolved: #15 

### 💻 작업 내용
- 날짜 필터링 기능 추가
- gitignore 수정

1. 해당 날짜에 상영시간 정보가 존재할 때
![image](https://github.com/DOSOPT-CDS-WEB-4/CGV-SERVER/assets/81404890/4ef631eb-c658-4214-92cd-561193f54516)

2. 해당 날짜에 상영시간 정보가 존재하지 않을 때
![image](https://github.com/DOSOPT-CDS-WEB-4/CGV-SERVER/assets/81404890/f1382a46-3133-49fb-902a-9df272b5765e)


### 📝 리뷰 노트
- ScheduleService의 getMovieScreenScheduleInfo() 메서드가 길어져 이를 좀 더 잘게 분리해야할지 고민이 듭니다.