### PR TITLE
[Feat] #23 - 좋아요 및 좋아요 취소 API 구현

### DIFF
--- a/cgv/src/main/java/org/sopt/server/cgv/controller/MovieController.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/controller/MovieController.java
@@ -6,6 +6,7 @@ import org.sopt.server.cgv.global.response.ApiResponse;
 import org.sopt.server.cgv.global.response.SuccessType;
 import org.sopt.server.cgv.service.MovieService;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,6 +22,11 @@ public class MovieController {
     @GetMapping
     public ApiResponse<List<MovieListResponseDto>> getMovieList() {
         return ApiResponse.success(SuccessType.GET_MOVIE_LIST_SUCCESS, movieService.getMovieList());
+    }
+
+    @GetMapping("/like/{movieId}")
+    public ApiResponse<?> applyLike(@PathVariable Long movieId) {
+        return movieService.applyLike(movieId) ? ApiResponse.success(SuccessType.MOVIE_DISLIKE_SUCCESS) : ApiResponse.success(SuccessType.MOVIE_LIKE_SUCCESS);
     }
 
 }

--- a/cgv/src/main/java/org/sopt/server/cgv/domain/Movie.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/domain/Movie.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -48,6 +49,10 @@ public class Movie {
     @Column(name = "like_count", nullable = false)
     private int like;
 
+    @Column(name = "like_able")
+    @ColumnDefault(value = "false")
+    private boolean likeAble;
+
     @Column(name = "poster", nullable = false)
     private String posterURL;
 
@@ -56,5 +61,11 @@ public class Movie {
 
     @OneToMany(mappedBy = "movie")
     List<Screen> screenList = new ArrayList<>();
+
+    public boolean applyLike() {
+        like += likeAble ? 1 : -1;
+        likeAble = !likeAble;
+        return likeAble;
+    }
 
 }

--- a/cgv/src/main/java/org/sopt/server/cgv/global/response/SuccessType.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/global/response/SuccessType.java
@@ -14,6 +14,8 @@ public enum SuccessType {
      * 200 OK
      */
     GET_MOVIE_LIST_SUCCESS(HttpStatus.OK, "무비차트 리스트 조회에 성공했습니다."),
+    MOVIE_LIKE_SUCCESS(HttpStatus.OK, "영화 좋아요에 성공했습니다."),
+    MOVIE_DISLIKE_SUCCESS(HttpStatus.OK, "영화 좋아요 취소에 성공했습니다."),
     GET_MOVIE_AND_SCREEN_TYPE_AND_SCHEDULE_LIST_SUCCESS(HttpStatus.OK, "영화 정보 및 상영관, 상영시간 조회에 성공했습니다."),
     PATCH_RESERVE_SUCCESS(HttpStatus.OK, "영화 에매 결제에 성공했습니다.");
 

--- a/cgv/src/main/java/org/sopt/server/cgv/service/MovieService.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/service/MovieService.java
@@ -28,4 +28,10 @@ public class MovieService {
         return movieRepository.findByIdOrThrow(movieId);
     }
 
+    @Transactional
+    public boolean applyLike(Long movieId) {
+        Movie movie = movieRepository.findByIdOrThrow(movieId);
+        return movie.applyLike();
+    }
+
 }


### PR DESCRIPTION
## 🔥*Pull Request*

### 📟 관련 이슈
- Resolved: #23 

### 💻 작업 내용
좋아요 및 좋아요 취소 API 구현
movie 테이블에 like_able이라는 컬럼을 만들어 좋아요 및 좋아요 취소가 가능하도록 했습니다.

### 📝 리뷰 노트
리턴값에 변경된 좋아요 수가 있어야 할까요..?
