### PR TITLE
[Refactor] #29 - 빠른예매 API에 schedule_id 추가

### DIFF
--- a/cgv/src/main/java/org/sopt/server/cgv/dto/response/MovieInfoResponseDto.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/dto/response/MovieInfoResponseDto.java
@@ -1,9 +1,12 @@
 package org.sopt.server.cgv.dto.response;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import org.sopt.server.cgv.domain.*;
 
 import java.time.LocalDate;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record MovieInfoResponseDto(
         String title,
         String summary,

--- a/cgv/src/main/java/org/sopt/server/cgv/dto/response/MovieScreenScheduleResponseDto.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/dto/response/MovieScreenScheduleResponseDto.java
@@ -1,10 +1,13 @@
 package org.sopt.server.cgv.dto.response;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import org.sopt.server.cgv.domain.Schedule;
 import org.sopt.server.cgv.domain.ScreenType;
 
 import java.time.LocalDateTime;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record MovieScreenScheduleResponseDto(
         Long scheduleId,
         ScreenType screenType,

--- a/cgv/src/main/java/org/sopt/server/cgv/dto/response/MovieScreenScheduleResponseDto.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/dto/response/MovieScreenScheduleResponseDto.java
@@ -6,6 +6,7 @@ import org.sopt.server.cgv.domain.ScreenType;
 import java.time.LocalDateTime;
 
 public record MovieScreenScheduleResponseDto(
+        Long scheduleId,
         ScreenType screenType,
         String place,
         LocalDateTime startTime,
@@ -16,6 +17,7 @@ public record MovieScreenScheduleResponseDto(
 ) {
     public static MovieScreenScheduleResponseDto of(Schedule schedule, LocalDateTime endTime, boolean reservationAvailability) {
         return new MovieScreenScheduleResponseDto(
+                schedule.getId(),
                 schedule.getScreen().getScreenType(),
                 schedule.getScreen().getPlace(),
                 schedule.getStartTime(),


### PR DESCRIPTION
## 🔥*Pull Request*

### 📟 관련 이슈
- Resolved: #29

### 💻 작업 내용
1. 빠른예매 API에 schedule_id 추가했습니다.
2. 상위 dto에만 JsonNaming을 snakecase로 적용하면 하위 dto에는 적용이 되지 않는 문제점을 발견하여 하위 dto에도 JsonNaming을 snakecase로 적용하였습니다. 

![image](https://github.com/DOSOPT-CDS-WEB-4/CGV-SERVER/assets/81404890/8d4c499a-e603-4d25-b16f-43667a19af4c)
- schedule_id가 전달되는 것을 확인할 수 있습니다.
- snakecase가 적용된 것을 확인할 수 있습니다.

### 📝 리뷰 노트

