### PR TITLE
[Chore] #31 - 빠른 예매 API 클라 측 요청 사항 반영

### DIFF
--- a/cgv/src/main/java/org/sopt/server/cgv/controller/ReservationController.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/controller/ReservationController.java
@@ -12,6 +12,7 @@ import org.sopt.server.cgv.service.MovieService;
 import org.sopt.server.cgv.service.RegionService;
 import org.sopt.server.cgv.service.ScheduleService;
 import org.sopt.server.cgv.service.ScreenService;
+import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -30,12 +31,15 @@ public class ReservationController {
     @GetMapping("/{movieId}")
     public ApiResponse<QuickReservationResponseDto> registerReservation(@PathVariable Long movieId,
                                                                         @RequestParam(value = "region") String regionName,
-                                                                        @RequestParam(value = "date") LocalDate date,
+                                                                        @RequestParam(value = "date", required = false) LocalDate date,
                                                                         @RequestParam(value = "type", required = false) List<String> screenTypes) {
         Movie movie = movieService.getMovieInfo(movieId);
         MovieInfoResponseDto movieInfo = MovieInfoResponseDto.of(movie);
         Region region = regionService.getRegionInfo(regionName);
         List<Long> screenIdList = screenService.getScreenIdList(movieId, region.getId(), screenTypes);
+        if (date == null) {
+            date = LocalDate.now();
+        }
         List<MovieScreenScheduleResponseDto> movieScreenSchedules = scheduleService.getMovieScreenScheduleInfo(screenIdList, movie.getRunningTime(), date);
         return ApiResponse.success(SuccessType.GET_MOVIE_AND_SCREEN_TYPE_AND_SCHEDULE_LIST_SUCCESS, QuickReservationResponseDto.of(
                 movieInfo, region, movieScreenSchedules));

--- a/cgv/src/main/java/org/sopt/server/cgv/dto/response/MovieInfoResponseDto.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/dto/response/MovieInfoResponseDto.java
@@ -11,9 +11,9 @@ public record MovieInfoResponseDto(
         String title,
         String summary,
         LocalDate openingDate,
-        Genre genre,
+        String genre,
         int runningTime,
-        Country country,
+        String country,
         String poster,
         String background
 ) {
@@ -22,9 +22,9 @@ public record MovieInfoResponseDto(
                 movie.getTitle(),
                 movie.getSummary(),
                 movie.getOpeningDate(),
-                movie.getGenre(),
+                movie.getGenre().getName(),
                 movie.getRunningTime(),
-                movie.getCountry(),
+                movie.getCountry().getName(),
                 movie.getPosterURL(),
                 movie.getBackgroundURL()
         );

--- a/cgv/src/main/java/org/sopt/server/cgv/dto/response/MovieInfoResponseDto.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/dto/response/MovieInfoResponseDto.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import org.sopt.server.cgv.domain.*;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record MovieInfoResponseDto(
         String title,
         String summary,
-        LocalDate openingDate,
+        String openingDate,
         String genre,
         int runningTime,
         String country,
@@ -21,7 +22,7 @@ public record MovieInfoResponseDto(
         return new MovieInfoResponseDto(
                 movie.getTitle(),
                 movie.getSummary(),
-                movie.getOpeningDate(),
+                movie.getOpeningDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")),
                 movie.getGenre().getName(),
                 movie.getRunningTime(),
                 movie.getCountry().getName(),

--- a/cgv/src/main/java/org/sopt/server/cgv/dto/response/MovieScreenScheduleResponseDto.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/dto/response/MovieScreenScheduleResponseDto.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record MovieScreenScheduleResponseDto(
         Long scheduleId,
-        ScreenType screenType,
+        String screenType,
         String place,
         LocalDateTime startTime,
         LocalDateTime endTime,
@@ -21,7 +21,7 @@ public record MovieScreenScheduleResponseDto(
     public static MovieScreenScheduleResponseDto of(Schedule schedule, LocalDateTime endTime, boolean reservationAvailability) {
         return new MovieScreenScheduleResponseDto(
                 schedule.getId(),
-                schedule.getScreen().getScreenType(),
+                schedule.getScreen().getScreenType().getName(),
                 schedule.getScreen().getPlace(),
                 schedule.getStartTime(),
                 endTime,

--- a/cgv/src/main/java/org/sopt/server/cgv/dto/response/MovieScreenScheduleResponseDto.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/dto/response/MovieScreenScheduleResponseDto.java
@@ -6,14 +6,16 @@ import org.sopt.server.cgv.domain.Schedule;
 import org.sopt.server.cgv.domain.ScreenType;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record MovieScreenScheduleResponseDto(
         Long scheduleId,
         String screenType,
         String place,
-        LocalDateTime startTime,
-        LocalDateTime endTime,
+        String date,
+        String startTime,
+        String endTime,
         int totalSeats,
         int emptySeats,
         boolean reservationAvailability
@@ -23,8 +25,9 @@ public record MovieScreenScheduleResponseDto(
                 schedule.getId(),
                 schedule.getScreen().getScreenType().getName(),
                 schedule.getScreen().getPlace(),
-                schedule.getStartTime(),
-                endTime,
+                schedule.getStartTime().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")),
+                schedule.getStartTime().format(DateTimeFormatter.ofPattern("HH:mm")),
+                endTime.format(DateTimeFormatter.ofPattern("HH:mm")),
                 schedule.getTotalSeats(),
                 schedule.getEmptySeats(),
                 reservationAvailability

--- a/cgv/src/main/java/org/sopt/server/cgv/dto/response/QuickReservationResponseDto.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/dto/response/QuickReservationResponseDto.java
@@ -10,19 +10,23 @@ import java.util.List;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record QuickReservationResponseDto(
         MovieInfoResponseDto movieInfo,
-        List<RegionName> regionNames,
-        RegionName currentRegion,
+        List<String> regionNames,
+        String currentRegion,
         Double distance,
-        List<ScreenType> screenTypes,
+        List<String> screenTypes,
         List<MovieScreenScheduleResponseDto> movieScreenSchedules
 ) {
     public static QuickReservationResponseDto of(MovieInfoResponseDto movieInfo, Region region, List<MovieScreenScheduleResponseDto> movieScreenSchedules) {
         return new QuickReservationResponseDto(
                 movieInfo,
-                Arrays.stream(RegionName.values()).toList(),
-                region.getRegionName(),
+                Arrays.stream(RegionName.values())
+                        .map(RegionName::getName)
+                        .toList(),
+                region.getRegionName().getName(),
                 region.getDistance(),
-                Arrays.stream(ScreenType.values()).toList(),
+                Arrays.stream(ScreenType.values())
+                        .map(ScreenType::getName)
+                        .toList(),
                 movieScreenSchedules
         );
     }

--- a/cgv/src/main/java/org/sopt/server/cgv/dto/response/QuickReservationResponseDto.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/dto/response/QuickReservationResponseDto.java
@@ -12,6 +12,7 @@ public record QuickReservationResponseDto(
         MovieInfoResponseDto movieInfo,
         List<RegionName> regionNames,
         RegionName currentRegion,
+        Double distance,
         List<ScreenType> screenTypes,
         List<MovieScreenScheduleResponseDto> movieScreenSchedules
 ) {
@@ -20,6 +21,7 @@ public record QuickReservationResponseDto(
                 movieInfo,
                 Arrays.stream(RegionName.values()).toList(),
                 region.getRegionName(),
+                region.getDistance(),
                 Arrays.stream(ScreenType.values()).toList(),
                 movieScreenSchedules
         );


### PR DESCRIPTION
## 🔥*Pull Request*

### 📟 관련 이슈
- Resolved: #31 

### 💻 작업 내용
<!-- 과제 내용을 자유롭게 적어주세요. -->
- ResponseBody에 거리값 추가
- 지역, 영화 장르, 상영관 종류와 같은 Enum들 ResponseDto에서는 원시값으로 가져오도록 변경
- 개봉일과 상영 스케줄 포맷 형식 변경 및 날짜/시작시간 분리
- 더미데이터 Schedule 12/07까지 데이터 추가 및 위치 (00관 00층)으로 변경
- API 명세서도 변경해두었습니다!

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
- 클라 측 요청 사항 중 위치만 선택했을 때 상영정보 뜨도록하는 부분만 작업해주시면 될 것 같습니다!! 
