### PR TITLE
[Refactor] #33 - 빠른 예매 API에서 일주일치 상영 스케쥴 전달

### DIFF
--- a/cgv/src/main/java/org/sopt/server/cgv/controller/ReservationController.java
+++ b/cgv/src/main/java/org/sopt/server/cgv/controller/ReservationController.java
@@ -31,16 +31,12 @@ public class ReservationController {
     @GetMapping("/{movieId}")
     public ApiResponse<QuickReservationResponseDto> registerReservation(@PathVariable Long movieId,
                                                                         @RequestParam(value = "region") String regionName,
-                                                                        @RequestParam(value = "date", required = false) LocalDate date,
                                                                         @RequestParam(value = "type", required = false) List<String> screenTypes) {
         Movie movie = movieService.getMovieInfo(movieId);
         MovieInfoResponseDto movieInfo = MovieInfoResponseDto.of(movie);
         Region region = regionService.getRegionInfo(regionName);
         List<Long> screenIdList = screenService.getScreenIdList(movieId, region.getId(), screenTypes);
-        if (date == null) {
-            date = LocalDate.now();
-        }
-        List<MovieScreenScheduleResponseDto> movieScreenSchedules = scheduleService.getMovieScreenScheduleInfo(screenIdList, movie.getRunningTime(), date);
+        List<MovieScreenScheduleResponseDto> movieScreenSchedules = scheduleService.getMovieScreenScheduleInfo(screenIdList, movie.getRunningTime());
         return ApiResponse.success(SuccessType.GET_MOVIE_AND_SCREEN_TYPE_AND_SCHEDULE_LIST_SUCCESS, QuickReservationResponseDto.of(
                 movieInfo, region, movieScreenSchedules));
     }


### PR DESCRIPTION
## 🔥*Pull Request*

### 📟 관련 이슈
- Resolved: #33 

### 💻 작업 내용
1. 빠른 예매 API에서 RequestParam에서 date를 삭제하였습니다.
2. 일주일치 상영 스케쥴을 전달하도록 수정하였습니다.
3. 기존 코드에서 메서드를 분리하여 더 깔끔하게 코드를 작성해보았습니다.

![image](https://github.com/DOSOPT-CDS-WEB-4/CGV-SERVER/assets/81404890/71a6b037-46a0-4c09-a1d2-7df789b161a1)
- 11.30과 12.1의 상영 정보가 동시에 존재함을 확인할 수 있습니다.

### 📝 리뷰 노트
stream과 메서드 분리 부분에서 자꾸 chatgpt의 도움을 받게 되는데 이를 지양하는 습관을 가져야 할 것 같습니다 ㅠ
